### PR TITLE
[Fix] 商品詳細・編集画面(管理側)のレイアウト調整

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,9 +27,9 @@ class Item < ApplicationRecord
 
 
 
-#消費財のメソッド
+#消費税のメソッド
   def with_tax_price
-    (price * 1.1).floor
+    (excluded_price * 1.1).floor
   end
 
 end

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,15 +1,16 @@
 <div class="container">
-  <div class="m-4">商品編集画面</div>
+<h3 class="m-4"><span style="background-color:#eee">商品編集</span></h3>
 </div>
 
 <%= form_with model: @item, url: admin_item_path, method: :patch do |f| %>
 
 <div class="container">
+<div class="row justify-content-center">
   <div class="col-2">
   </div>
 
   <div class="col-7">
-    <table>
+    <table class="table table-borderless">
       <tr>
         <td class="col-2">商品画像</td>
         <td><%= f.file_field :image, accept: "image/*" %></td>
@@ -17,12 +18,12 @@
 
       <tr>
         <td>商品名</td>
-        <td><%= f.text_field :name,placeholder: "商品名" %></td>
+        <td><%= f.text_field :name,placeholder: "商品名", :size=>"30x10" %></td>
       </tr>
 
       <tr>
         <td>商品説明</td>
-        <td><%= f.text_area :caption,placeholder: "ここに説明を記述します" %></td>
+        <td><%= f.text_area :caption,placeholder: "ここに説明を記述します", :size=>"30x7" %></td>
       </tr>
 
       <tr>
@@ -32,7 +33,7 @@
 
       <tr>
         <td>税抜価格</td>
-        <td><%= f.text_field :excluded_price,placeholder: "1000" %>円</td>
+        <td><%= f.text_field :excluded_price,placeholder: "1000", :size=>"10x10" %>円</td>
       </tr>
 
       <tr>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <div class= col-4>
-      <h4 class="m-4"><span>商品一覧</span></h4>
+      <h3 class="m-4"><span style="background-color:#eee">商品一覧</span></h3>
     </div>
 
 
@@ -19,15 +19,15 @@
 
 
 <!--一覧項目-->
-<div class="container">
+<div class="container text-center">
   <div class="row">
     <div class="col-11">
     <table class="table">
-      <thead>
+      <thead class="bg-light">
         <tr>
           <th>商品ID</th>
           <th>商品名</th>
-          <th>税込価格</th>
+          <th>税抜価格</th>
           <th>ジャンル</th>
           <th>ステータス</th>
         </tr>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -16,7 +16,7 @@
 
 
   <div class="container">
-  <div class="row">
+  　<div class="row">
     <div class="col-2">
     </div>
     <div class="col-7">

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,9 +1,8 @@
 <div class="container">
-  <h4 class="m-4">商品詳細</span></h4>
+  <h3 class="m-4"><span style="background-color:#eee">商品詳細</span></h3>
 </div>
 
 <br>
-
 <div class="container">
 <div class="row justify-content-center">
   <div class="text-center col-3">
@@ -27,16 +26,18 @@
       <tr>
         <td>税込価格<br>
             (税抜価格)</td>
-        <td><%= @item.excluded_price.to_s(:delimited) %> 円</td>
+        <td><%= @item.with_tax_price.to_s(:delimited) %>
+            <span>(<%= @item.excluded_price.to_s(:delimited) %>)</span>円
+        </td>
       </tr>
       <tr>
         <td class="col-3">販売ステータス</td>
         <td>
-        　<% if @item.is_status == true %>
-     　      <p class="text-success font-weight-bold">販売中</p>
-    　 　   <% else %>
-         　  <p class='text-secondary font-weight-bold'>販売停止中</p>
-    　　    <% end %>
+          <% if @item.is_status == true %>
+            <p class="text-success font-weight-bold">販売中</p>
+          <% else %>
+            <p class='text-secondary font-weight-bold'>販売停止中</p>
+          <% end %>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
商品詳細・編集画面(管理者側)の修正を行いました。
・タイトルの大きさ、背景色
・消費税込みの価格の表示(詳細画面)
・販売ステータスの表示ズレ(　〃　)
・入力画面のサイズ調整

